### PR TITLE
Minor Makefile Tweaks

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,10 +12,10 @@ main: sudoku_gpu.o sudoku_cpu.o
 	${NVCC} ${INC} ${OPT} -o main sudoku_gpu.o
 
 sudoku_gpu.o: sudoku_gpu.cu
-	$(NVCC) ${INC} ${OPT} ${CUDAFLAGS} -std=c++11 -c sudoku_gpu.cu
+	$(NVCC) ${INC} ${OPT} ${CUDAFLAGS} -std=c++14 -c sudoku_gpu.cu
 
 sudoku_cpu.o: sudoku_cpu.cu
-	$(NVCC) ${INC} ${OPT} ${CUDAFLAGS} -std=c++11 -c sudoku_cpu.cu
+	$(NVCC) ${INC} ${OPT} ${CUDAFLAGS} -std=c++14 -c sudoku_cpu.cu
 
 sudoku_gpu: sudoku_gpu.o
 	${NVCC} ${INC} ${CUDAFLAGS} -o sudoku_gpu sudoku_gpu.o

--- a/makefile
+++ b/makefile
@@ -1,25 +1,26 @@
-NVCC=nvcc -I/home/purechar/assignment1/parallel-sudoku-solver/Common
+NVCC=nvcc
 CUDAFLAGS=-arch=sm_30
 OPT=-g -G
+INC=-I./Common
 
 .PHONY: all clean
 
 all: sudoku_gpu sudoku_cpu
 
 main: sudoku_gpu.o sudoku_cpu.o
-	${NVCC} ${OPT} -o main sudoku_gpu.o
+	${NVCC} ${INC} ${OPT} -o main sudoku_gpu.o
 
 sudoku_gpu.o: sudoku_gpu.cu
-	$(NVCC) ${OPT} ${CUDAFLAGS} -std=c++11 -c sudoku_gpu.cu
+	$(NVCC) ${INC} ${OPT} ${CUDAFLAGS} -std=c++11 -c sudoku_gpu.cu
 
 sudoku_cpu.o: sudoku_cpu.cu
-	$(NVCC) ${OPT} ${CUDAFLAGS} -std=c++11 -c sudoku_cpu.cu
+	$(NVCC) ${INC} ${OPT} ${CUDAFLAGS} -std=c++11 -c sudoku_cpu.cu
 
 sudoku_gpu: sudoku_gpu.o
-	${NVCC} ${CUDAFLAGS} -o sudoku_gpu sudoku_gpu.o
+	${NVCC} ${INC} ${CUDAFLAGS} -o sudoku_gpu sudoku_gpu.o
 
 sudoku_cpu: sudoku_cpu.o
-	${NVCC} ${CUDAFLAGS} -o sudoku_cpu sudoku_cpu.o
+	${NVCC} ${INC} ${CUDAFLAGS} -o sudoku_cpu sudoku_cpu.o
 
 clean:
 	rm -f *.o sudoku_gpu, sudoku_cpu

--- a/makefile
+++ b/makefile
@@ -1,4 +1,5 @@
 NVCC=nvcc
+# NB: change this to sm_50 if it doesn't work for you
 CUDAFLAGS=-arch=sm_30
 OPT=-g -G
 INC=-I./Common

--- a/makefile
+++ b/makefile
@@ -1,23 +1,25 @@
-NVCC=nvcc -I /home/purechar/assignment1/parallel-sudoku-solver/Common
+NVCC=nvcc -I/home/purechar/assignment1/parallel-sudoku-solver/Common
+CUDAFLAGS=-arch=sm_30
+OPT=-g -G
 
-CUDAFLAGS= -arch=sm_30
-OPT= -g -G
-RM=/bin/rm -f
+.PHONY: all clean
+
 all: sudoku_gpu sudoku_cpu
 
 main: sudoku_gpu.o sudoku_cpu.o
 	${NVCC} ${OPT} -o main sudoku_gpu.o
 
 sudoku_gpu.o: sudoku_gpu.cu
-	$(NVCC) ${OPT} $(CUDAFLAGS)	-std=c++11 -c sudoku_gpu.cu
+	$(NVCC) ${OPT} ${CUDAFLAGS} -std=c++11 -c sudoku_gpu.cu
 
 sudoku_cpu.o: sudoku_cpu.cu
-	$(NVCC) ${OPT} $(CUDAFLAGS)	-std=c++11 -c sudoku_cpu.cu
+	$(NVCC) ${OPT} ${CUDAFLAGS} -std=c++11 -c sudoku_cpu.cu
 
 sudoku_gpu: sudoku_gpu.o
 	${NVCC} ${CUDAFLAGS} -o sudoku_gpu sudoku_gpu.o
 
 sudoku_cpu: sudoku_cpu.o
 	${NVCC} ${CUDAFLAGS} -o sudoku_cpu sudoku_cpu.o
+
 clean:
-	${RM} *.o sudoku_gpu, sudoku_cpu
+	rm -f *.o sudoku_gpu, sudoku_cpu

--- a/makefile
+++ b/makefile
@@ -24,4 +24,4 @@ sudoku_cpu: sudoku_cpu.o
 	${NVCC} ${INC} ${CUDAFLAGS} -o sudoku_cpu sudoku_cpu.o
 
 clean:
-	rm -f *.o sudoku_gpu, sudoku_cpu
+	rm -f *.o sudoku_gpu sudoku_cpu


### PR DESCRIPTION
- change standard to c++14
	Thrust screams that it wants c++14,  
	we can just change the standard to silence the warnings lol
- note about arch
	some might have to change the `-arch=` flag  
	it seems `sm_30` isn't supported (any morre? idk)  
	see: https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
- use relative include
	headers weren't being found :sob:
- minor cleanup
